### PR TITLE
Fix for strict standard and Firefox compatibility

### DIFF
--- a/scripts/core.js
+++ b/scripts/core.js
@@ -5,5 +5,5 @@ if(localStorage.defaultTranslation == undefined){
 
 function goToTranslation(term, translation){
     var translateLanguages = translation.split('-');
-    window.open('http://www.wordreference.com/' + translateLanguages[0] + translateLanguages[1] + '/' + term, '_blank');
+    chrome.tabs.create({ url:'http://www.wordreference.com/' + translateLanguages[0] + translateLanguages[1] + '/' + term });
 }


### PR DESCRIPTION
This is a little fix for Firefox compatibility. FFx is more strict and standard then Chrome so you have to do this.

If you accept this little fix you will be able to upload it on the Firefox addon store directory.