### PR TITLE
First create, then bind

### DIFF
--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -1,7 +1,7 @@
 $(document).ready(function(){
-    $("#default_languages").change(onDefaultLanguageChange);
     renderPopupUi();
     populateDefaultLanguagesMenu();
+    $("#default_languages").change(onDefaultLanguageChange);    
 });
 
 function populateDefaultLanguagesMenu() {


### PR DESCRIPTION
The `change` event is never fired on the select element because is binded before its creation.